### PR TITLE
Initialize Next.js scaffolding

### DIFF
--- a/mcp-omni-platform/.gitignore
+++ b/mcp-omni-platform/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+out
+.env.local
+.DS_Store

--- a/mcp-omni-platform/_mock_data/servers.ts
+++ b/mcp-omni-platform/_mock_data/servers.ts
@@ -1,0 +1,71 @@
+import { Server, UserPermissions } from '@/types/mcp';
+
+export const getMockExternalRemoteServer = (name: string): Server => ({
+  id: name,
+  server_name: name,
+  displayName: 'Community GitHub Server (Remote)',
+  author: 'community-dev',
+  apiType: 'Remote (SSE/HTTP)',
+  hostingContext: 'External Server',
+  version: '1.0.0',
+  versions: ['1.0.0', '0.9.0'],
+  tags: ['community'],
+  stats: { usage: '1.2k/wk', rating: 4.5, forks: 10, qualityScore: 'B+' },
+  dates: { published: '2024-01-15', lastUpdated: '2024-04-20' },
+  externalLinks: {
+    sourceRepo: 'https://github.com/example/server',
+    issueTracker: 'https://github.com/example/server/issues',
+    officialDocs: 'https://example.com/docs'
+  },
+  description: 'An external server hosted on GitHub.',
+  readmeContent: '# External Remote Server\nThis is a test server.',
+  tools: [
+    {
+      name: 'sayHello',
+      description: 'Returns a greeting',
+      parameters: [{ name: 'name', type: 'string', required: true, description: 'Name to greet' }],
+      outputSchema: { type: 'string' },
+      canonicalPageUrl: '/tools/sayHello'
+    }
+  ],
+  schemaConfig: {
+    connection: { baseUrlPattern: 'https://api.example.com/{version}' },
+    runtimeConfig: [{ name: 'API_KEY', isSecret: true, description: 'API Key', required: true }],
+    manifest: { name, version: '1.0.0' }
+  },
+});
+
+export const getMockOmniHostedManagedServer = (name: string): Server => ({
+  id: name,
+  server_name: name,
+  displayName: 'My Hosted Salesforce Server',
+  author: 'omni-user',
+  apiType: 'Remote (SSE/HTTP)',
+  hostingContext: 'Hosted by Omni',
+  version: '1.0.0',
+  versions: ['1.0.0'],
+  tags: ['hosted'],
+  stats: { usage: '5k/wk', rating: 4.8, forks: 2, qualityScore: 'A' },
+  dates: { published: '2024-05-10', lastUpdated: '2024-05-20' },
+  description: 'An Omni-hosted server.',
+  readmeContent: '# My Hosted Server\nManaged by Omni.',
+  tools: [
+    {
+      name: 'getLead',
+      description: 'Fetch lead info',
+      parameters: [{ name: 'id', type: 'string', required: true, description: 'Lead ID' }],
+      outputSchema: { type: 'object' }
+    }
+  ],
+  schemaConfig: { connection: {}, runtimeConfig: [], manifest: {} },
+  deploymentDetails: {
+    status: 'Running',
+    sseEndpointUrl: `wss://${name}.omni.mcphub.ai/`,
+    configuredEnvVars: [{ name: 'API_KEY', isSecret: true, value: '****' }],
+  },
+});
+
+export const getMockUserPermissions = (canManage: boolean): UserPermissions => ({
+  canManageDeployment: canManage,
+  canEditOrgSettings: canManage,
+});

--- a/mcp-omni-platform/app/(app)/layout.tsx
+++ b/mcp-omni-platform/app/(app)/layout.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import AppLayout from '@/layouts/AppLayout';
+
+export default function AppSectionLayout({ children }: { children: ReactNode }) {
+  return <AppLayout>{children}</AppLayout>;
+}

--- a/mcp-omni-platform/app/(app)/page.tsx
+++ b/mcp-omni-platform/app/(app)/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>(app)/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/(auth)/login/page.tsx
+++ b/mcp-omni-platform/app/(auth)/login/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>(auth)/login/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/(auth)/signup/page.tsx
+++ b/mcp-omni-platform/app/(auth)/signup/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>(auth)/signup/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/(marketing)/about/page.tsx
+++ b/mcp-omni-platform/app/(marketing)/about/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>(marketing)/about/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/(marketing)/contact/page.tsx
+++ b/mcp-omni-platform/app/(marketing)/contact/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>(marketing)/contact/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/(marketing)/layout.tsx
+++ b/mcp-omni-platform/app/(marketing)/layout.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import MarketingLayout from '@/layouts/MarketingLayout';
+
+export default function MarketingSectionLayout({ children }: { children: ReactNode }) {
+  return <MarketingLayout>{children}</MarketingLayout>;
+}

--- a/mcp-omni-platform/app/(marketing)/pricing/page.tsx
+++ b/mcp-omni-platform/app/(marketing)/pricing/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>(marketing)/pricing/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/(marketing)/privacy/page.tsx
+++ b/mcp-omni-platform/app/(marketing)/privacy/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>(marketing)/privacy/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/(marketing)/terms/page.tsx
+++ b/mcp-omni-platform/app/(marketing)/terms/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>(marketing)/terms/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/clients/[client_name]/page.tsx
+++ b/mcp-omni-platform/app/clients/[client_name]/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>clients/[client_name]/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/compare/page.tsx
+++ b/mcp-omni-platform/app/compare/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>compare/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/dashboard/hosted-servers/new/configure/page.tsx
+++ b/mcp-omni-platform/app/dashboard/hosted-servers/new/configure/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>dashboard/hosted-servers/new/configure/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/dashboard/hosted-servers/new/page.tsx
+++ b/mcp-omni-platform/app/dashboard/hosted-servers/new/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>dashboard/hosted-servers/new/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/dashboard/hosted-servers/page.tsx
+++ b/mcp-omni-platform/app/dashboard/hosted-servers/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>dashboard/hosted-servers/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/dashboard/layout.tsx
+++ b/mcp-omni-platform/app/dashboard/layout.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import DashboardLayout from '@/layouts/DashboardLayout';
+
+export default function DashboardSectionLayout({ children }: { children: ReactNode }) {
+  return <DashboardLayout>{children}</DashboardLayout>;
+}

--- a/mcp-omni-platform/app/dashboard/page.tsx
+++ b/mcp-omni-platform/app/dashboard/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>dashboard/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/globals.css
+++ b/mcp-omni-platform/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/mcp-omni-platform/app/layout.tsx
+++ b/mcp-omni-platform/app/layout.tsx
@@ -1,0 +1,16 @@
+import './globals.css';
+import { ReactNode } from 'react';
+import AppLayout from '@/layouts/AppLayout';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ErrorBoundary>
+          <AppLayout>{children}</AppLayout>
+        </ErrorBoundary>
+      </body>
+    </html>
+  );
+}

--- a/mcp-omni-platform/app/page.tsx
+++ b/mcp-omni-platform/app/page.tsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <div>Homepage Placeholder</div>;
+}

--- a/mcp-omni-platform/app/playground/page.tsx
+++ b/mcp-omni-platform/app/playground/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>playground/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/posts/[post_slug]/page.tsx
+++ b/mcp-omni-platform/app/posts/[post_slug]/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>posts/[post_slug]/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/posts/page.tsx
+++ b/mcp-omni-platform/app/posts/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>posts/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/servers/[server_name]/page.tsx
+++ b/mcp-omni-platform/app/servers/[server_name]/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+import { useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { useServerDetailStore } from '@/store/server-detail-store';
+import Breadcrumbs from '@/components/shared/Breadcrumbs';
+import ServerHeader from '@/components/mcp/server-detail/ServerHeader';
+import RightSidebar from '@/components/mcp/server-detail/RightSidebar';
+import InstallHelperModal from '@/components/mcp/server-detail/InstallHelperModal';
+import OverviewTabContent from '@/components/mcp/server-detail/OverviewTabContent';
+import ToolsTabContent from '@/components/mcp/server-detail/ToolsTabContent';
+import SchemaConfigTabContent from '@/components/mcp/server-detail/SchemaConfigTabContent';
+import InstallationUsageTabContent from '@/components/mcp/server-detail/InstallationUsageTabContent';
+import SecurityScoreTabContent from '@/components/mcp/server-detail/SecurityScoreTabContent';
+import ReviewsTabContent from '@/components/mcp/server-detail/ReviewsTabContent';
+import UseCasesTabContent from '@/components/mcp/server-detail/UseCasesTabContent';
+import RelatedItemsTabContent from '@/components/mcp/server-detail/RelatedItemsTabContent';
+import VersionsTabContent from '@/components/mcp/server-detail/VersionsTabContent';
+import DeploymentMonitoringTabContent from '@/components/mcp/server-detail/DeploymentMonitoringTabContent';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui';
+
+export default function ServerDetailPage() {
+  const params = useParams<{ server_name: string }>();
+  const { serverData, isLoading, fetchServerData, activeTab, setActiveTab, openInstallHelperModal } = useServerDetailStore();
+
+  useEffect(() => {
+    if (params?.server_name) {
+      fetchServerData(params.server_name, true);
+    }
+  }, [params?.server_name, fetchServerData]);
+
+  if (isLoading || !serverData) return <div>Loading...</div>;
+
+  const crumbs = [
+    { href: '/', label: 'MCP Omni' },
+    { href: '/servers', label: 'Servers' },
+    { href: `/servers/${serverData.server_name}`, label: serverData.displayName }
+  ];
+
+  return (
+    <div className="flex gap-4">
+      <div className="flex-1">
+        <Breadcrumbs items={crumbs} />
+        <ServerHeader server={serverData} />
+        <Tabs value={activeTab} className="mt-4">
+          <TabsList>
+            <TabsTrigger value="overview" onClick={() => setActiveTab('overview')}>Overview</TabsTrigger>
+            <TabsTrigger value="tools" onClick={() => setActiveTab('tools')}>Tools</TabsTrigger>
+            <TabsTrigger value="schemaconfig" onClick={() => setActiveTab('schemaconfig')}>Schema & Config</TabsTrigger>
+            <TabsTrigger value="installation" onClick={() => setActiveTab('installation')}>Installation & Usage</TabsTrigger>
+            <TabsTrigger value="security" onClick={() => setActiveTab('security')}>Security & Score</TabsTrigger>
+            <TabsTrigger value="reviews" onClick={() => setActiveTab('reviews')}>Reviews & Comments</TabsTrigger>
+            <TabsTrigger value="usecases" onClick={() => setActiveTab('usecases')}>Use Cases</TabsTrigger>
+            <TabsTrigger value="related" onClick={() => setActiveTab('related')}>Related Items</TabsTrigger>
+            <TabsTrigger value="versions" onClick={() => setActiveTab('versions')}>Versions</TabsTrigger>
+            {serverData.hostingContext === 'Hosted by Omni' && (
+              <TabsTrigger value="deployment" onClick={() => setActiveTab('deployment')}>Deployment & Monitoring</TabsTrigger>
+            )}
+          </TabsList>
+          <OverviewTabContent server={serverData} permissions={null} />
+          <ToolsTabContent server={serverData} permissions={null} />
+          <SchemaConfigTabContent server={serverData} permissions={null} />
+          <InstallationUsageTabContent server={serverData} permissions={null} />
+          <SecurityScoreTabContent server={serverData} permissions={null} />
+          <ReviewsTabContent server={serverData} permissions={null} />
+          <UseCasesTabContent server={serverData} permissions={null} />
+          <RelatedItemsTabContent server={serverData} permissions={null} />
+          <VersionsTabContent server={serverData} permissions={null} />
+          {serverData.hostingContext === 'Hosted by Omni' && (
+            <DeploymentMonitoringTabContent server={serverData} permissions={null} />
+          )}
+        </Tabs>
+      </div>
+      <div className="w-72">
+        <RightSidebar server={serverData} permissions={null} onManage={() => setActiveTab('deployment')} onGetInfo={openInstallHelperModal} />
+      </div>
+      <InstallHelperModal server={serverData} />
+    </div>
+  );
+}

--- a/mcp-omni-platform/app/settings/api-tokens/page.tsx
+++ b/mcp-omni-platform/app/settings/api-tokens/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>settings/api-tokens/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/settings/billing/page.tsx
+++ b/mcp-omni-platform/app/settings/billing/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>settings/billing/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/settings/layout.tsx
+++ b/mcp-omni-platform/app/settings/layout.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import SettingsLayout from '@/layouts/SettingsLayout';
+
+export default function SettingsSectionLayout({ children }: { children: ReactNode }) {
+  return <SettingsLayout>{children}</SettingsLayout>;
+}

--- a/mcp-omni-platform/app/settings/members/page.tsx
+++ b/mcp-omni-platform/app/settings/members/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>settings/members/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/settings/organization/page.tsx
+++ b/mcp-omni-platform/app/settings/organization/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>settings/organization/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/settings/page.tsx
+++ b/mcp-omni-platform/app/settings/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>settings/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/settings/profile/page.tsx
+++ b/mcp-omni-platform/app/settings/profile/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>settings/profile/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/settings/serversets/page.tsx
+++ b/mcp-omni-platform/app/settings/serversets/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>settings/serversets/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/tools/[tool_definition_id]/page.tsx
+++ b/mcp-omni-platform/app/tools/[tool_definition_id]/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>tools/[tool_definition_id]/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/use-cases/[use_case_slug]/page.tsx
+++ b/mcp-omni-platform/app/use-cases/[use_case_slug]/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>use-cases/[use_case_slug]/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/use-cases/page.tsx
+++ b/mcp-omni-platform/app/use-cases/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>use-cases/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/app/users/[username]/page.tsx
+++ b/mcp-omni-platform/app/users/[username]/page.tsx
@@ -1,0 +1,1 @@
+export default function Page() { return <div>users/[username]/page.tsx placeholder</div>; }

--- a/mcp-omni-platform/components.json
+++ b/mcp-omni-platform/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/mcp-omni-platform/components/mcp/server-detail/DeploymentMonitoringTabContent.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/DeploymentMonitoringTabContent.tsx
@@ -1,0 +1,12 @@
+import { TabsContent } from '@/components/ui'
+import { Server, UserPermissions } from '@/types/mcp'
+
+interface Props { server: Server; permissions: UserPermissions | null }
+
+export default function DeploymentMonitoringTabContent({ server, permissions }: Props) {
+  return (
+    <TabsContent value="deployment">
+      <div className="p-4 text-sm text-muted-foreground">Deployment & Monitoring placeholder</div>
+    </TabsContent>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/InstallHelperModal.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/InstallHelperModal.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogClose, Tabs, TabsList, TabsTrigger, TabsContent, Button } from '@/components/ui'
+import { Server } from '@/types/mcp'
+import { useServerDetailStore } from '@/store/server-detail-store'
+import { McpIcon } from '@/components/shared/McpIcon'
+
+export default function InstallHelperModal({ server }: { server: Server }) {
+  const { isInstallHelperModalOpen, closeInstallHelperModal } = useServerDetailStore()
+  return (
+    <Dialog open={isInstallHelperModalOpen} onOpenChange={closeInstallHelperModal}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Connection Info</DialogTitle>
+          <DialogDescription>Use these snippets to connect</DialogDescription>
+        </DialogHeader>
+        <Tabs value="json">
+          <TabsList>
+            <TabsTrigger value="json">JSON</TabsTrigger>
+            <TabsTrigger value="url">URL</TabsTrigger>
+          </TabsList>
+          <TabsContent value="json">
+            <pre className="bg-muted p-2 rounded text-sm overflow-auto">{JSON.stringify({endpoint: server.deploymentDetails?.sseEndpointUrl}, null, 2)}</pre>
+          </TabsContent>
+          <TabsContent value="url">
+            <div className="flex items-center gap-2"><input className="w-full border p-1" readOnly value={server.deploymentDetails?.sseEndpointUrl}/><Button size="icon"><McpIcon name="copy"/></Button></div>
+          </TabsContent>
+        </Tabs>
+        <DialogClose asChild>
+          <Button variant="outline">Close</Button>
+        </DialogClose>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/InstallationUsageTabContent.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/InstallationUsageTabContent.tsx
@@ -1,0 +1,12 @@
+import { TabsContent } from '@/components/ui'
+import { Server, UserPermissions } from '@/types/mcp'
+
+interface Props { server: Server; permissions: UserPermissions | null }
+
+export default function InstallationUsageTabContent({ server, permissions }: Props) {
+  return (
+    <TabsContent value="installation">
+      <div className="p-4 text-sm text-muted-foreground">Installation & Usage placeholder</div>
+    </TabsContent>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/OverviewTabContent.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/OverviewTabContent.tsx
@@ -1,0 +1,12 @@
+import { TabsContent } from '@/components/ui'
+import { Server, UserPermissions } from '@/types/mcp'
+
+interface Props { server: Server; permissions: UserPermissions | null }
+
+export default function OverviewTabContent({ server, permissions }: Props) {
+  return (
+    <TabsContent value="overview">
+      <div className="p-4 text-sm text-muted-foreground">Overview placeholder</div>
+    </TabsContent>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/RelatedItemsTabContent.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/RelatedItemsTabContent.tsx
@@ -1,0 +1,12 @@
+import { TabsContent } from '@/components/ui'
+import { Server, UserPermissions } from '@/types/mcp'
+
+interface Props { server: Server; permissions: UserPermissions | null }
+
+export default function RelatedItemsTabContent({ server, permissions }: Props) {
+  return (
+    <TabsContent value="related">
+      <div className="p-4 text-sm text-muted-foreground">Related Items placeholder</div>
+    </TabsContent>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/ReviewsTabContent.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/ReviewsTabContent.tsx
@@ -1,0 +1,12 @@
+import { TabsContent } from '@/components/ui'
+import { Server, UserPermissions } from '@/types/mcp'
+
+interface Props { server: Server; permissions: UserPermissions | null }
+
+export default function ReviewsTabContent({ server, permissions }: Props) {
+  return (
+    <TabsContent value="reviews">
+      <div className="p-4 text-sm text-muted-foreground">Reviews placeholder</div>
+    </TabsContent>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/RightSidebar.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/RightSidebar.tsx
@@ -1,0 +1,34 @@
+import { Server, UserPermissions } from '@/types/mcp'
+import { Button, Badge } from '@/components/ui'
+import { McpIcon } from '@/components/shared/McpIcon'
+
+interface Props {
+  server: Server
+  permissions: UserPermissions | null
+  onManage?: () => void
+  onGetInfo?: () => void
+}
+
+export default function RightSidebar({ server, permissions, onManage, onGetInfo }: Props) {
+  const isHosted = server.hostingContext === 'Hosted by Omni'
+  return (
+    <aside className="p-4 space-y-4">
+      <div className="space-y-2">
+        {isHosted && permissions?.canManageDeployment && (
+          <Button onClick={onManage}><McpIcon name="settings" className="mr-2"/>Manage Deployment</Button>
+        )}
+        <Button onClick={onGetInfo}><McpIcon name="code" className="mr-2"/>Get Connection Info</Button>
+        <Button variant="outline"><McpIcon name="playground" className="mr-2"/>Test in Playground</Button>
+        <Button variant="outline"><McpIcon name="bookmark" className="mr-2"/>Bookmark</Button>
+      </div>
+      <div className="border p-2 rounded">
+        <div className="font-semibold mb-2">Summary</div>
+        <div className="text-sm space-y-1">
+          <div>Type: <Badge>{server.apiType}</Badge></div>
+          <div>Hosting: <Badge>{server.hostingContext}</Badge></div>
+          {server.author && <div>Author: {server.author}</div>}
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/SchemaConfigTabContent.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/SchemaConfigTabContent.tsx
@@ -1,0 +1,19 @@
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui'
+import { Server, UserPermissions } from '@/types/mcp'
+
+interface Props { server: Server; permissions: UserPermissions | null }
+
+export default function SchemaConfigTabContent({ server, permissions }: Props) {
+  return (
+    <Tabs value="connection" className="p-4">
+      <TabsList>
+        <TabsTrigger value="connection">Connection</TabsTrigger>
+        <TabsTrigger value="runtimeconfig">Runtime Config</TabsTrigger>
+        <TabsTrigger value="manifest">Manifest</TabsTrigger>
+      </TabsList>
+      <TabsContent value="connection"><div>Connection info placeholder</div></TabsContent>
+      <TabsContent value="runtimeconfig"><div>Runtime config placeholder</div></TabsContent>
+      <TabsContent value="manifest"><div>Manifest placeholder</div></TabsContent>
+    </Tabs>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/SecurityScoreTabContent.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/SecurityScoreTabContent.tsx
@@ -1,0 +1,12 @@
+import { TabsContent } from '@/components/ui'
+import { Server, UserPermissions } from '@/types/mcp'
+
+interface Props { server: Server; permissions: UserPermissions | null }
+
+export default function SecurityScoreTabContent({ server, permissions }: Props) {
+  return (
+    <TabsContent value="security">
+      <div className="p-4 text-sm text-muted-foreground">Security & Score placeholder</div>
+    </TabsContent>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/ServerHeader.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/ServerHeader.tsx
@@ -1,0 +1,49 @@
+import { Server } from '@/types/mcp';
+import { Badge, Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui';
+import { McpIcon } from '@/components/shared/McpIcon';
+
+export default function ServerHeader({ server }: { server: Server }) {
+  return (
+    <div className="flex flex-col gap-2 p-4 border-b">
+      <h1 className="text-2xl font-bold">{server.displayName}</h1>
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <span>by {server.author}</span>
+        {server.isVerifiedAuthor && <McpIcon name="shield" className="text-blue-500" />}
+        {server.statusBadge && <Badge variant="outline">{server.statusBadge}</Badge>}
+      </div>
+      <Select>
+        <SelectTrigger>{server.version}</SelectTrigger>
+        <SelectContent>
+          {server.versions.map(v => <SelectItem key={v} value={v}>{v}</SelectItem>)}
+        </SelectContent>
+      </Select>
+      <div className="flex flex-wrap gap-2 mt-2">
+        <Badge variant="secondary"><McpIcon name="api" className="mr-1" /> {server.apiType}</Badge>
+        <Badge variant="secondary"><McpIcon name={server.hostingContext === 'Hosted by Omni' ? 'omnilogo' : 'externallink'} className="mr-1" /> {server.hostingContext}</Badge>
+      </div>
+      <div className="flex flex-wrap gap-1 mt-2">
+        {server.tags.map(tag => <Badge key={tag} variant="outline">{tag}</Badge>)}
+      </div>
+      {server.stats && (
+        <div className="flex flex-wrap gap-4 mt-2 text-sm text-muted-foreground">
+          {server.stats.usage && <span><McpIcon name="download" className="mr-1" />{server.stats.usage}</span>}
+          {server.stats.rating && <span><McpIcon name="star" className="mr-1" />{server.stats.rating}</span>}
+          {server.stats.forks && <span><McpIcon name="fork" className="mr-1" />{server.stats.forks}</span>}
+          {server.stats.qualityScore && <span><McpIcon name="deployment" className="mr-1" />{server.stats.qualityScore}</span>}
+        </div>
+      )}
+      {server.dates && (
+        <div className="text-sm text-muted-foreground">
+          Published {server.dates.published} • Updated {server.dates.lastUpdated}
+        </div>
+      )}
+      {server.externalLinks && (
+        <div className="flex gap-2 text-sm">
+          {server.externalLinks.sourceRepo && <a className="text-blue-600" href={server.externalLinks.sourceRepo}>Source</a>}
+          {server.externalLinks.issueTracker && <a className="text-blue-600" href={server.externalLinks.issueTracker}>Issues</a>}
+          {server.externalLinks.officialDocs && <a className="text-blue-600" href={server.externalLinks.officialDocs}>Docs</a>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcp-omni-platform/components/mcp/server-detail/ToolsTabContent.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/ToolsTabContent.tsx
@@ -1,0 +1,12 @@
+import { TabsContent } from '@/components/ui'
+import { Server, UserPermissions } from '@/types/mcp'
+
+interface Props { server: Server; permissions: UserPermissions | null }
+
+export default function ToolsTabContent({ server, permissions }: Props) {
+  return (
+    <TabsContent value="tools">
+      <div className="p-4 text-sm text-muted-foreground">Tools placeholder</div>
+    </TabsContent>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/UseCasesTabContent.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/UseCasesTabContent.tsx
@@ -1,0 +1,12 @@
+import { TabsContent } from '@/components/ui'
+import { Server, UserPermissions } from '@/types/mcp'
+
+interface Props { server: Server; permissions: UserPermissions | null }
+
+export default function UseCasesTabContent({ server, permissions }: Props) {
+  return (
+    <TabsContent value="usecases">
+      <div className="p-4 text-sm text-muted-foreground">Use Cases placeholder</div>
+    </TabsContent>
+  )
+}

--- a/mcp-omni-platform/components/mcp/server-detail/VersionsTabContent.tsx
+++ b/mcp-omni-platform/components/mcp/server-detail/VersionsTabContent.tsx
@@ -1,0 +1,12 @@
+import { TabsContent } from '@/components/ui'
+import { Server, UserPermissions } from '@/types/mcp'
+
+interface Props { server: Server; permissions: UserPermissions | null }
+
+export default function VersionsTabContent({ server, permissions }: Props) {
+  return (
+    <TabsContent value="versions">
+      <div className="p-4 text-sm text-muted-foreground">Versions placeholder</div>
+    </TabsContent>
+  )
+}

--- a/mcp-omni-platform/components/shared/Breadcrumbs.tsx
+++ b/mcp-omni-platform/components/shared/Breadcrumbs.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+import { McpIcon } from './McpIcon'
+
+interface Crumb { href: string; label: string }
+
+export default function Breadcrumbs({ items }: { items: Crumb[] }) {
+  return (
+    <nav className="text-sm mb-2">
+      {items.map((c, i) => (
+        <span key={i} className="mr-1">
+          {i > 0 && <McpIcon name="chevronright" className="inline-block mx-1" />}
+          <Link href={c.href} className="text-blue-600 hover:underline">{c.label}</Link>
+        </span>
+      ))}
+    </nav>
+  )
+}

--- a/mcp-omni-platform/components/shared/DashboardSidebarNav.tsx
+++ b/mcp-omni-platform/components/shared/DashboardSidebarNav.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link';
+
+export function DashboardSidebarNav() {
+  return (
+    <nav className="p-4 space-y-2 border-r">
+      <Link href="/dashboard/hosted-servers">Hosted Servers</Link>
+    </nav>
+  );
+}

--- a/mcp-omni-platform/components/shared/ErrorBoundary.tsx
+++ b/mcp-omni-platform/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,24 @@
+'use client'
+import React from 'react'
+
+export class ErrorBoundary extends React.Component<{children: React.ReactNode}, {hasError: boolean}> {
+  constructor(props: {children: React.ReactNode}) {
+    super(props)
+    this.state = {hasError: false}
+  }
+
+  static getDerivedStateFromError() {
+    return {hasError: true}
+  }
+
+  componentDidCatch(error: any, info: any) {
+    console.error('ErrorBoundary caught', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div className="p-4 text-red-500">Something went wrong.</div>
+    }
+    return this.props.children
+  }
+}

--- a/mcp-omni-platform/components/shared/Footer.tsx
+++ b/mcp-omni-platform/components/shared/Footer.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export function Footer() {
+  return (
+    <footer className="border-t p-4 text-center text-sm text-muted-foreground">
+      © {new Date().getFullYear()} MCP Omni. All rights reserved.
+      <div className="space-x-4 mt-2">
+        <Link href="/about">About</Link>
+        <Link href="/contact">Contact</Link>
+        <Link href="/terms">Terms</Link>
+        <Link href="/privacy">Privacy</Link>
+      </div>
+    </footer>
+  );
+}

--- a/mcp-omni-platform/components/shared/LoadingSpinner.tsx
+++ b/mcp-omni-platform/components/shared/LoadingSpinner.tsx
@@ -1,0 +1,3 @@
+export function LoadingSpinner() {
+  return <div className="animate-spin">Loading...</div>;
+}

--- a/mcp-omni-platform/components/shared/MainNav.tsx
+++ b/mcp-omni-platform/components/shared/MainNav.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+import { McpIcon } from './McpIcon';
+
+export function MainNav() {
+  return (
+    <nav className="border-b p-4 flex justify-between items-center">
+      <Link href="/" className="font-bold text-lg flex items-center">
+        <McpIcon name="OmniLogo" className="h-6 w-6 mr-2" />
+        MCP Omni
+      </Link>
+      <div className="space-x-4">
+        <Link href="/registry">Registry</Link>
+        <Link href="/playground">Playground</Link>
+        <Link href="/dashboard/hosted-servers">Dashboard</Link>
+        <Link href="/posts">Blog</Link>
+        <Link href="/pricing">Pricing</Link>
+        <Link href="/settings/profile">Settings</Link>
+      </div>
+    </nav>
+  );
+}

--- a/mcp-omni-platform/components/shared/McpIcon.tsx
+++ b/mcp-omni-platform/components/shared/McpIcon.tsx
@@ -1,0 +1,100 @@
+import {
+  Server, Terminal, Link as LinkIcon, Zap, ShieldCheck, MessageSquare,
+  BarChartHorizontalBig, Settings, GitFork, Star, Download, BookOpen, Bug,
+  Play, Copy as CopyIcon, Plus, MoreHorizontal, ChevronDown, ChevronUp,
+  ChevronsUpDown, Search, Edit, Trash2, Redo, FileText, FolderOpen, Cpu,
+  List, Eye, EyeOff, RefreshCcw, Bookmark, Code, Copy, CompareArrows,
+  Wand2, Info, Link2
+} from 'lucide-react';
+
+interface McpIconProps {
+  name: string;
+  className?: string;
+  size?: number;
+}
+
+export const McpIcon = ({ name, className, size = 16 }: McpIconProps) => {
+  const iconProps = { className, size };
+  switch (name.toLowerCase()) {
+    case 'api':
+      return <Server {...iconProps} />;
+    case 'terminal':
+      return <Terminal {...iconProps} />;
+    case 'externallink':
+      return <LinkIcon {...iconProps} />;
+    case 'omnilogo':
+      return <Zap {...iconProps} />;
+    case 'security':
+    case 'shield':
+      return <ShieldCheck {...iconProps} />;
+    case 'reviews':
+    case 'comments':
+      return <MessageSquare {...iconProps} />;
+    case 'deployment':
+      return <BarChartHorizontalBig {...iconProps} />;
+    case 'settings':
+      return <Settings {...iconProps} />;
+    case 'fork':
+      return <GitFork {...iconProps} />;
+    case 'star':
+      return <Star {...iconProps} />;
+    case 'download':
+      return <Download {...iconProps} />;
+    case 'docs':
+    case 'readme':
+      return <BookOpen {...iconProps} />;
+    case 'issue':
+      return <Bug {...iconProps} />;
+    case 'playground':
+      return <Play {...iconProps} />;
+    case 'copy':
+      return <CopyIcon {...iconProps} />;
+    case 'add':
+      return <Plus {...iconProps} />;
+    case 'more':
+      return <MoreHorizontal {...iconProps} />;
+    case 'chevrondown':
+      return <ChevronDown {...iconProps} />;
+    case 'chevronup':
+      return <ChevronUp {...iconProps} />;
+    case 'chevronsupdown':
+      return <ChevronsUpDown {...iconProps} />;
+    case 'search':
+      return <Search {...iconProps} />;
+    case 'edit':
+      return <Edit {...iconProps} />;
+    case 'delete':
+      return <Trash2 {...iconProps} />;
+    case 'redeploy':
+      return <Redo {...iconProps} />;
+    case 'logs':
+      return <FileText {...iconProps} />;
+    case 'files':
+      return <FolderOpen {...iconProps} />;
+    case 'cpu':
+      return <Cpu {...iconProps} />;
+    case 'tools':
+      return <List {...iconProps} />;
+    case 'eyeopen':
+      return <Eye {...iconProps} />;
+    case 'eyeclosed':
+      return <EyeOff {...iconProps} />;
+    case 'restart':
+      return <RefreshCcw {...iconProps} />;
+    case 'bookmark':
+      return <Bookmark {...iconProps} />;
+    case 'code':
+      return <Code {...iconProps} />;
+    case 'compare':
+      return <CompareArrows {...iconProps} />;
+    case 'skillset':
+      return <Wand2 {...iconProps} />;
+    case 'info':
+      return <Info {...iconProps} />;
+    case 'link':
+      return <Link2 {...iconProps} />;
+    default:
+      console.warn(`McpIcon: Unknown icon name "${name}"`);
+      return null;
+  }
+};

--- a/mcp-omni-platform/components/shared/PageHeader.tsx
+++ b/mcp-omni-platform/components/shared/PageHeader.tsx
@@ -1,0 +1,3 @@
+export function PageHeader({ title }: { title: string }) {
+  return <h1 className="text-2xl font-bold mb-4">{title}</h1>;
+}

--- a/mcp-omni-platform/components/shared/SettingsSidebarNav.tsx
+++ b/mcp-omni-platform/components/shared/SettingsSidebarNav.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export function SettingsSidebarNav() {
+  return (
+    <nav className="p-4 space-y-2 border-r">
+      <Link href="/settings/profile">Profile</Link><br />
+      <Link href="/settings/organization">Organization</Link><br />
+      <Link href="/settings/members">Members</Link><br />
+      <Link href="/settings/billing">Billing</Link><br />
+      <Link href="/settings/api-tokens">API Tokens</Link><br />
+      <Link href="/settings/serversets">Serversets</Link>
+    </nav>
+  );
+}

--- a/mcp-omni-platform/components/shared/UserAvatar.tsx
+++ b/mcp-omni-platform/components/shared/UserAvatar.tsx
@@ -1,0 +1,3 @@
+export function UserAvatar() {
+  return <div className="w-6 h-6 bg-gray-300 rounded-full" />;
+}

--- a/mcp-omni-platform/components/ui/index.tsx
+++ b/mcp-omni-platform/components/ui/index.tsx
@@ -1,0 +1,32 @@
+export function Badge({ children, variant }: { children: React.ReactNode; variant?: string }) {
+  return <span className={`px-2 py-1 border rounded ${variant}`}>{children}</span>;
+}
+
+export function Button({ children, onClick, variant = 'default', size = 'default' }: { children: React.ReactNode; onClick?: () => void; variant?: string; size?: string }) {
+  const styles = variant === 'outline' ? 'border' : 'bg-blue-600 text-white'
+  return (
+    <button onClick={onClick} className={`px-2 py-1 rounded ${styles}`}>{children}</button>
+  )
+}
+
+export function Select({ children }: { children: React.ReactNode }) { return <div>{children}</div>; }
+export function SelectTrigger({ children }: { children: React.ReactNode }) { return <button>{children}</button>; }
+export function SelectContent({ children }: { children: React.ReactNode }) { return <div>{children}</div>; }
+export function SelectItem({ children }: { children: React.ReactNode; value: string }) { return <div>{children}</div>; }
+
+export function Tabs({ children, value, className }: { children: React.ReactNode; value?: string; className?: string }) { return <div className={className}>{children}</div> }
+export function TabsList({ children }: { children: React.ReactNode }) { return <div className="flex gap-2 border-b mb-2">{children}</div> }
+export function TabsTrigger({ children, value }: { children: React.ReactNode; value: string }) { return <button className="px-2 py-1" data-value={value}>{children}</button> }
+export function TabsContent({ children, value }: { children: React.ReactNode; value: string }) { return <div data-value={value}>{children}</div> }
+
+export function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return <input {...props} className={`border p-1 rounded ${props.className||''}`} />
+}
+
+export function Dialog({ children, open, onOpenChange }: { children: React.ReactNode; open?: boolean; onOpenChange?: (v:boolean)=>void }) { return open ? <div>{children}</div> : null }
+export function DialogTrigger({ children }: { children: React.ReactNode }) { return <>{children}</> }
+export function DialogContent({ children }: { children: React.ReactNode }) { return <div className="border p-4 bg-white rounded shadow-md">{children}</div> }
+export function DialogHeader({ children }: { children: React.ReactNode }) { return <div className="mb-2">{children}</div> }
+export function DialogTitle({ children }: { children: React.ReactNode }) { return <h3 className="text-lg font-semibold">{children}</h3> }
+export function DialogDescription({ children }: { children: React.ReactNode }) { return <p className="text-sm text-muted-foreground">{children}</p> }
+export function DialogClose({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) { return <div className="mt-2">{children}</div> }

--- a/mcp-omni-platform/layouts/AppLayout.tsx
+++ b/mcp-omni-platform/layouts/AppLayout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import { MainNav } from '@/components/shared/MainNav';
+import { Footer } from '@/components/shared/Footer';
+
+export default function AppLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <MainNav />
+      <main className="flex-grow container mx-auto px-4 py-8">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/mcp-omni-platform/layouts/DashboardLayout.tsx
+++ b/mcp-omni-platform/layouts/DashboardLayout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+import { DashboardSidebarNav } from '@/components/shared/DashboardSidebarNav';
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex">
+      <DashboardSidebarNav />
+      <div className="flex-grow p-4">{children}</div>
+    </div>
+  );
+}

--- a/mcp-omni-platform/layouts/MarketingLayout.tsx
+++ b/mcp-omni-platform/layouts/MarketingLayout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import { MainNav } from '@/components/shared/MainNav';
+import { Footer } from '@/components/shared/Footer';
+
+export default function MarketingLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <MainNav />
+      <main className="flex-grow container mx-auto px-4 py-8">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/mcp-omni-platform/layouts/SettingsLayout.tsx
+++ b/mcp-omni-platform/layouts/SettingsLayout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+import { SettingsSidebarNav } from '@/components/shared/SettingsSidebarNav';
+
+export default function SettingsLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex">
+      <SettingsSidebarNav />
+      <div className="flex-grow p-4">{children}</div>
+    </div>
+  );
+}

--- a/mcp-omni-platform/lib/mcp-utils.ts
+++ b/mcp-omni-platform/lib/mcp-utils.ts
@@ -1,0 +1,3 @@
+export function formatDate(date: string) {
+  return new Date(date).toLocaleDateString();
+}

--- a/mcp-omni-platform/lib/routes.ts
+++ b/mcp-omni-platform/lib/routes.ts
@@ -1,0 +1,7 @@
+export const R_HOME = "/";
+export const R_REGISTRY = "/";
+export const R_SERVER_DETAIL = (serverName: string) => `/servers/${serverName}`;
+export const R_SETTINGS_PROFILE = "/settings/profile";
+export const R_PLAYGROUND = "/playground";
+export const R_DASHBOARD_HOSTED_SERVERS = "/dashboard/hosted-servers";
+export const R_SETTINGS = "/settings";

--- a/mcp-omni-platform/lib/utils.ts
+++ b/mcp-omni-platform/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: string[]) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/mcp-omni-platform/next-env.d.ts
+++ b/mcp-omni-platform/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/mcp-omni-platform/next.config.mjs
+++ b/mcp-omni-platform/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/mcp-omni-platform/package.json
+++ b/mcp-omni-platform/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "mcp-omni-platform",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "zustand": "4.4.0",
+    "lucide-react": "0.325.0",
+    "react-hook-form": "7.48.2",
+    "zod": "3.22.4",
+    "@hookform/resolvers": "3.3.0",
+    "@radix-ui/react-tabs": "1.0.7",
+    "@radix-ui/react-select": "1.0.4",
+    "@radix-ui/react-dialog": "1.0.4",
+    "class-variance-authority": "0.7.0",
+    "tailwind-merge": "2.2.2",
+    "clsx": "2.1.0",
+    "sonner": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.4.2",
+    "@types/react": "18.2.14",
+    "@types/react-dom": "18.2.6",
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.23",
+    "tailwindcss": "3.3.3",
+    "eslint": "8.50.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "5.2.2"
+  }
+}

--- a/mcp-omni-platform/postcss.config.js
+++ b/mcp-omni-platform/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/mcp-omni-platform/store/auth-store.ts
+++ b/mcp-omni-platform/store/auth-store.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+import { User, UserPermissions } from '@/types/mcp';
+
+interface AuthState {
+  isAuthenticated: boolean;
+  user: User | null;
+  permissions: UserPermissions | null;
+  login: (user: User, permissions: UserPermissions) => void;
+  logout: () => void;
+  setServerSpecificPermissions: (canManageDeployment: boolean) => void;
+}
+
+export const useAuthStore = create<AuthState>((set, get) => ({
+  isAuthenticated: false,
+  user: null,
+  permissions: null,
+  login: (user, permissions) => set({ isAuthenticated: true, user, permissions }),
+  logout: () => set({ isAuthenticated: false, user: null, permissions: null }),
+  setServerSpecificPermissions: (canManageDeployment) => {
+    const currentPermissions = get().permissions;
+    set({ permissions: { ...currentPermissions, canManageDeployment } as UserPermissions });
+  }
+}));

--- a/mcp-omni-platform/store/server-detail-store.ts
+++ b/mcp-omni-platform/store/server-detail-store.ts
@@ -1,0 +1,62 @@
+import { create } from 'zustand';
+import { Server, UserPermissions } from '@/types/mcp';
+import { getMockExternalRemoteServer, getMockOmniHostedManagedServer, getMockUserPermissions } from '@/_mock_data/servers';
+
+interface ServerDetailState {
+  serverData: Server | null;
+  isLoading: boolean;
+  error: string | null;
+  activeTab: string;
+  isInstallHelperModalOpen: boolean;
+  currentUserPermissions: UserPermissions | null;
+
+  fetchServerData: (serverName: string, isUserAdminForThisServer: boolean) => void;
+  setActiveTab: (tabId: string) => void;
+  openInstallHelperModal: () => void;
+  closeInstallHelperModal: () => void;
+  updateServerEnvVar: (name: string, value: string) => void;
+}
+
+export const useServerDetailStore = create<ServerDetailState>((set, get) => ({
+  serverData: null,
+  isLoading: false,
+  error: null,
+  activeTab: 'overview',
+  isInstallHelperModalOpen: false,
+  currentUserPermissions: null,
+
+  fetchServerData: (serverName, isUserAdminForThisServer) => {
+    set({ isLoading: true, error: null });
+    let mockServer: Server;
+    if (serverName === 'external-remote-test') {
+      mockServer = getMockExternalRemoteServer(serverName);
+    } else {
+      mockServer = getMockOmniHostedManagedServer(serverName);
+    }
+    const permissions = getMockUserPermissions(isUserAdminForThisServer);
+    setTimeout(() => {
+      set({ serverData: mockServer, currentUserPermissions: permissions, isLoading: false, activeTab: 'overview' });
+    }, 500);
+  },
+  setActiveTab: (tabId) => set({ activeTab: tabId }),
+  openInstallHelperModal: () => set({ isInstallHelperModalOpen: true }),
+  closeInstallHelperModal: () => set({ isInstallHelperModalOpen: false }),
+  updateServerEnvVar: (name, value) => {
+    const currentServer = get().serverData;
+    if (currentServer && currentServer.deploymentDetails?.configuredEnvVars) {
+      const updatedEnvVars = currentServer.deploymentDetails.configuredEnvVars.map(ev =>
+        ev.name === name ? { ...ev, value } : ev
+      );
+      set(state => ({
+        serverData: {
+          ...state.serverData!,
+          deploymentDetails: {
+            ...state.serverData!.deploymentDetails!,
+            configuredEnvVars: updatedEnvVars,
+          }
+        }
+      }));
+      console.log(`Mocked ENV VAR update: ${name} = ${value}`);
+    }
+  },
+}));

--- a/mcp-omni-platform/tailwind.config.ts
+++ b/mcp-omni-platform/tailwind.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    './src/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config

--- a/mcp-omni-platform/tsconfig.json
+++ b/mcp-omni-platform/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/mcp-omni-platform/types/mcp.ts
+++ b/mcp-omni-platform/types/mcp.ts
@@ -1,0 +1,95 @@
+export type ServerHostingType = 'External Server' | 'Hosted by Omni';
+export type ServerApiType = 'Remote (SSE/HTTP)' | 'Local (STDIO)';
+export type ServerStatusBadge = 'Official' | 'Verified' | 'Community';
+export type DeploymentStatus = 'Running' | 'Stopped' | 'Building' | 'Failed' | 'Starting' | 'Stopping...';
+
+export interface EnvVar {
+  name: string;
+  value?: string;
+  isSecret: boolean;
+  description?: string;
+  required?: boolean;
+  defaultValue?: string;
+}
+
+export interface ToolParameter {
+  name: string;
+  type: string;
+  required: boolean;
+  description: string;
+  default?: any;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters: ToolParameter[];
+  outputSchema?: any;
+  canonicalPageUrl?: string;
+}
+
+export interface ServerSchemaConfig {
+  connection: { [key: string]: any };
+  runtimeConfig: EnvVar[];
+  manifest?: any;
+}
+
+export interface Server {
+  id: string;
+  server_name: string;
+  displayName: string;
+  namespace?: string;
+  author?: string;
+  isVerifiedAuthor?: boolean;
+  statusBadge?: ServerStatusBadge;
+  version: string;
+  versions: string[];
+  apiType: ServerApiType;
+  hostingContext: ServerHostingType;
+  tags: string[];
+  stats?: {
+    usage?: string;
+    rating?: number;
+    ratingCount?: number;
+    forks?: number;
+    rank?: string;
+    qualityScore?: string;
+    securityStatus?: 'Passed' | 'Failed' | 'N/A';
+  };
+  dates?: {
+    published: string;
+    lastUpdated: string;
+  };
+  externalLinks?: {
+    sourceRepo?: string;
+    issueTracker?: string;
+    officialDocs?: string;
+  };
+  description: string;
+  readmeContent: string;
+  tools: ToolDefinition[];
+  schemaConfig: ServerSchemaConfig;
+  deploymentDetails?: {
+    status: DeploymentStatus;
+    instanceId?: string;
+    sseEndpointUrl?: string;
+    resourceUsage?: { cpu: string; memory: string; networkIO: string; callCounts: number; errorRate: number };
+    configuredEnvVars?: EnvVar[];
+    buildLogs?: string[];
+    runtimeLogs?: string[];
+    lastDeployed?: string;
+  };
+  registrySources?: { name: string; logoUrl?: string; sourceUrl: string }[];
+}
+
+export interface User {
+  id: string;
+  name?: string;
+  email: string;
+  avatarUrl?: string;
+}
+
+export interface UserPermissions {
+  canManageDeployment: boolean;
+  canEditOrgSettings: boolean;
+}


### PR DESCRIPTION
## Summary
- setup Next.js scaffolding with basic layouts and placeholder pages
- add shared components and Zustand stores
- include sample server detail page and mock data
- expand server detail page scaffolding with tabs, sidebar, modals, and mock data

## Testing
- `npm run build` *(fails: next not found)*
